### PR TITLE
This adds better handling for previously unpublished packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repo includes the following actions:
 For more detailed explanations see the respective readmes.
 Nevertheless here's a minimal example of these actions in use.
 
-```yaml
+```yml
 - id: version-metadata
   uses: Quantco/ui-actions/version-metadata@v1
   with:

--- a/publish/README.md
+++ b/publish/README.md
@@ -17,7 +17,7 @@ The decision is made using the following procedure:
 
 ### GitHub Workflow
 
-```yaml
+```yml
 - id: publish # This will be the reference for getting the outputs later on.
   uses: Quantco/ui-actions/publish@v1
 
@@ -34,6 +34,8 @@ The decision is made using the following procedure:
     # the json output of the version-metadata action
     # you can of course replace version-metadata with differernt action but it needs to have the same data structure
     version-metadata-json: ${{ steps.version-metadata.outputs.json }}
+    # Turns `# publish` into `# publish - <package-name>` in the reason output. Purely cosmetic.
+    package-name: "<package-name>
 ```
 
 ### Outputs
@@ -115,7 +117,7 @@ Let's look at the 3 following situations and what each results in
 In this example `lib/package.json` is used to get the version.
 Be sure to replace `<YOUR PACKAGE NAME>` with your own package.
 
-```yaml
+```yml
 # checkout, setup-node, etc. omitted
 
 - id: version-metadata

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -18,6 +18,9 @@ inputs:
   version-metadata-json:
     description: The JSON output of the version-metadata action
     required: true
+  package-name:
+    description: Turns `# publish` into `# publish - <package-name>` in the reason output. Purely cosmetic.
+    required: false
 
 outputs:
   publish:

--- a/publish/package.json
+++ b/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "An action that decides if a new release should be published",
   "scripts": {
     "build": "tsup",

--- a/publish/src/index.ts
+++ b/publish/src/index.ts
@@ -176,23 +176,36 @@ const run = () => {
   //    -> tried to publish 1.0.1 again (failure)
   const detectedNonLinearHistory = versionMetadata.newVersion === latestRegistryVersion
 
-  if (versionMetadata.changed && !detectedNonLinearHistory) {
+  // if the package hasn't been published before we fall back to `0.0.0` as latestRegistryVersion
+  // if there are relevant files that changed we want to publish while ignoring latestRegistryVersion
+  // we thus use versionMetadata.newVersion instead of latestRegistryVersion
+  // this is all handled in the first if-statement of the if-else chain below
+  const isFirstPublish = latestRegistryVersion === '0.0.0'
+
+  if ((versionMetadata.changed && !detectedNonLinearHistory) || (relevantFiles.length > 0 && isFirstPublish)) {
     return {
       publish: true,
       version: versionMetadata.newVersion,
-      reason: preparedSummary(relevantFiles, versionMetadata, oldVersion, versionMetadata.newVersion, false)
+      reason: preparedSummary(
+        relevantFiles,
+        versionMetadata,
+        oldVersion,
+        versionMetadata.newVersion,
+        false,
+        isFirstPublish
+      )
     }
   } else if (relevantFiles.length > 0 || detectedNonLinearHistory) {
     const incrementedVersion = incrementVersion(latestRegistryVersion, incrementType)
     return {
       publish: true,
       version: incrementedVersion,
-      reason: preparedSummary(relevantFiles, versionMetadata, oldVersion, incrementedVersion, true)
+      reason: preparedSummary(relevantFiles, versionMetadata, oldVersion, incrementedVersion, true, false)
     }
   } else {
     return {
       publish: false,
-      reason: preparedSummary(relevantFiles, versionMetadata, oldVersion, oldVersion, false)
+      reason: preparedSummary(relevantFiles, versionMetadata, oldVersion, oldVersion, false, false)
     }
   }
 }

--- a/publish/src/schemas.ts
+++ b/publish/src/schemas.ts
@@ -12,6 +12,7 @@ const incrementTypeSchema = z.enum(['pre-release', 'patch', 'minor', 'major'])
 const relevantFilesSchema = z.array(z.string())
 const packageJsonFilePathSchema = z.string()
 const latestRegistryVersionSchema = semverSchema
+const packageNameSchema = z.string().optional()
 
 const versionMetadataJsonUnchangedSchema = z.object({
   changed: z.literal(false),
@@ -63,5 +64,6 @@ export {
   relevantFilesSchema,
   packageJsonFilePathSchema,
   latestRegistryVersionSchema,
-  versionMetadataJsonSchema
+  versionMetadataJsonSchema,
+  packageNameSchema
 }

--- a/publish/src/utils.ts
+++ b/publish/src/utils.ts
@@ -57,7 +57,13 @@ const incrementVersion = (version: string, type: 'pre-release' | 'patch' | 'mino
 
 const summary =
   (
-    { owner, repo, base, head }: { owner: string; repo: string; base: string; head: string },
+    {
+      owner,
+      repo,
+      base,
+      head,
+      packageName
+    }: { owner: string; repo: string; base: string; head: string; packageName?: string },
     packageJsonFilePath: string,
     relevantFilesGlobs: string[]
   ) =>
@@ -103,7 +109,7 @@ Thus a new version was published.
 
     // now add the wrapper around it that is the same for all cases
     const template = (innerText: string) => `
-# publish
+# publish${packageName !== undefined ? ` - ${packageName}` : ''}
 
 <sup>This action checks if the version number has been updated in the repository and gathers a bit of metadata. Visit [ui-actions](https://github.com/Quantco/ui-actions) to get started.</sup>
 

--- a/publish/src/utils.ts
+++ b/publish/src/utils.ts
@@ -100,10 +100,15 @@ Thus a new version was published.
   When incrementing the version number manually the relevant files aren't used in the decision making process, nevertheless here they are
   <br />
 
-  ${relevantFiles.map((file) => `- ${file}`).join('\n')}
+  ${relevantFiles
+    .map((file) => `  - ${file}`)
+    .join('\n')
+    .trim()}
 
-  <sup>What is considered a relevant change? Anything that matches any of the following file globs:</sup><br />
-  <sup>${relevantFilesGlobs.map((fileGlob) => `\`${fileGlob}\``).join(', ')}</sup>
+  <sup>
+    What is considered a relevant change? Anything that matches any of the following file globs:<br />
+    ${relevantFilesGlobs.map((fileGlob) => `\`${fileGlob}\``).join(', ')}
+  </sup>
 
 </details>`
 
@@ -124,6 +129,7 @@ ${innerText}
       .split('\n')
       .map((line) => `  ${line}`)
       .join('\n') /* indent each line by 2 spaces */
+      .trim() /* trim to remove duplicate '  ' on the first line */
   }
   \`\`\`
 </details>

--- a/publish/src/utils.ts
+++ b/publish/src/utils.ts
@@ -72,27 +72,36 @@ const summary =
     rawJson: VersionMetadataResponse,
     oldVersion: string,
     newVersion: string,
-    didAutoIncrement: boolean
+    didAutoIncrement: boolean,
+    isFirstPublish: boolean
   ) => {
     // start of with actual content that greatly depends on the decision about publishing, not publishing, etc.
     const noNewVersion = `No relevant changes were made since the last time.`
 
-    const newVersionAutoDetected = `Relevant files were changed which resulted in a version bump from \`${oldVersion}\` to \`${newVersion}\`.
+    const newVersionAutoDetected = `Relevant files were changed ${
+      isFirstPublish
+        ? `and the package hasn't been published before. Thus \`${newVersion}\` was published`
+        : `which resulted in a version bump from \`${oldVersion}\` to \`${newVersion}\``
+    }.
 
 <details>
   <summary>Relevant files</summary>
 
   <br />
 
-  ${relevantFiles.map((file) => `- ${file}`).join('\n  ')}
+  ${relevantFiles
+    .map((file) => `  - ${file}`)
+    .join('\n')
+    .trim()}
 
   <sup>What is considered a relevant change? Anything that matches any of the following file globs:</sup><br />
   <sup>${relevantFilesGlobs.map((fileGlob) => `\`${fileGlob}\``).join(', ')}</sup>
 
 </details>`
 
-    const newVersionManuallySet = `Version in \`${packageJsonFilePath}\` was updated from \`${oldVersion}\` to \`${newVersion}\`.
-Thus a new version was published.
+    const newVersionManuallySet = `Version in \`${packageJsonFilePath}\` was updated from \`${oldVersion}\` to \`${newVersion}\`${
+      isFirstPublish ? ` and the package hasn't been published before` : ''
+    }. Thus \`${newVersion}\` was published${isFirstPublish ? ' for the first time' : ''}.
 
 <details>
   <summary>Relevant files</summary>
@@ -143,7 +152,11 @@ ${innerText}
 `
     // decide which one to use
     const reason =
-      oldVersion === newVersion ? noNewVersion : didAutoIncrement ? newVersionAutoDetected : newVersionManuallySet
+      oldVersion === newVersion && !isFirstPublish
+        ? noNewVersion
+        : didAutoIncrement
+        ? newVersionAutoDetected
+        : newVersionManuallySet
 
     return template(reason)
   }

--- a/version-metadata/README.md
+++ b/version-metadata/README.md
@@ -13,7 +13,7 @@ This action only computes metadata and doesn't push git tags, publishes a packag
 
 You have to set up a step like this in your workflow (this assumes you've already [checked out](https://github.com/actions/checkout) your repo and [set up Node](https://github.com/actions/setup-node)):
 
-```yaml
+```yml
 - id: version # This will be the reference for getting the outputs.
   uses: Quantco/ui-actions/version-metadata@v1 # You can choose the version/branch you prefer.
 
@@ -25,12 +25,8 @@ You have to set up a step like this in your workflow (this assumes you've alread
     # Default: package.json
     file: ./lib/package.json
 
-    # If you want this action to work on private repositories, you need to provide
-    # a token with the correct authorization. You can use the built-in `GITHUB_TOKEN`
-    # in most cases :)
-    # reference: https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-actions#github_token-secret
-    # Additionally providing a token for public repositories might be useful as this
-    # Increases your GitHub api rate limit.
+    # Needed for both private and public repos as the GitHub api client needs a token
+    # to be instantiated.
     token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -47,7 +43,7 @@ Let's assume you just merged a pull request into main in which you did the follo
 
 The action will output the following:
 
-```yaml
+```yml
 changed: true
 oldVersion: '1.2.2'
 newVersion: '1.2.4'
@@ -108,7 +104,7 @@ To access these outputs, you need to access the context of the step you previous
 
 With step id `version` you'll find the outputs at `steps.version.outputs.OUTPUT_NAME`.
 
-```yaml
+```yml
 - name: Check if version has been updated
   id: version
   uses: Quantco/ui-actions/version-metadata@v1
@@ -125,7 +121,7 @@ With step id `version` you'll find the outputs at `steps.version.outputs.OUTPUT_
 
 ## Examples
 
-```yaml
+```yml
 # checkout, setup-node, etc. omitted
 
 - name: Check if version has been updated

--- a/version-metadata/package.json
+++ b/version-metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "version-metadata",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "An action that checks wether your package.json version has been updated with a bit of additional metadata",
   "scripts": {
     "build": "tsup",

--- a/version-metadata/src/utils.ts
+++ b/version-metadata/src/utils.ts
@@ -262,11 +262,36 @@ const categorizeChangedFiles = (
   return { all, added, modified, removed, renamed }
 }
 
+const parseVersionFromFileContents = (
+  fileContent: string,
+  sha: string,
+  gitUrl: string | null
+): { success: false; error: string } | { success: true; version: string } => {
+  let parsed: { version?: string }
+  try {
+    parsed = JSON.parse(fileContent)
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to parse JSON of package.json file (url: ${gitUrl}, sha: ${sha}, content: "${fileContent}")`
+    }
+  }
+  if (!parsed.version) {
+    return {
+      success: false,
+      error: `version is undefined, this should not happen (url: ${gitUrl}, sha: ${sha})`
+    }
+  }
+
+  return { success: true, version: parsed.version }
+}
+
 export {
   parseSemverVersion,
   getSemverDiffType,
   computeResponseFromChanges,
   determineBaseAndHead,
   deduplicateConsecutive,
-  categorizeChangedFiles
+  categorizeChangedFiles,
+  parseVersionFromFileContents
 }


### PR DESCRIPTION
This adds a fallback to version `0.0.0` for commits missing a `package.json` (or whatever is specified) file, the reason being that it is likely this action is added at the same time as the package.json file, meaning that the base commit has no package.json file

Additionally an edge-case for the latest registry version being `0.0.0` has also been added. If the latest registry version is `0.0.0` the output summary changes a slight bit and the version to publish is no longer the latest registry version incremented but the new/unchanged version taken from `version-metadata`.

Some smaller things have also been improved, such as formatting/indentation in the output summary.