### PR TITLE
Work around a GitHub actions bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           version: 6.32.2
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: pnpm
 
       - run: pnpm install
@@ -47,7 +47,7 @@ jobs:
           version: 6.32.2
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: pnpm
 
       - run: pnpm install

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -12,7 +12,7 @@ jobs:
           version: 6.32.2
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: pnpm
 
       - run: pnpm install

--- a/publish/package.json
+++ b/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "An action that decides if a new release should be published",
   "scripts": {
     "build": "tsup",

--- a/version-metadata/package.json
+++ b/version-metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "version-metadata",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "An action that checks wether your package.json version has been updated with a bit of additional metadata",
   "scripts": {
     "build": "tsup",

--- a/version-metadata/test/index.mjs
+++ b/version-metadata/test/index.mjs
@@ -22,6 +22,19 @@ const tests = [
     }
   },
   {
+    description: 'Handles "missing" / all zeroes `before` value correctly on push',
+    base: '0000000000000000000000000000000000000000',
+    head: '4cedd64e7615d69f7bcd229fc960d3e1a6f4b496',
+    repo: 'Quantco/ui-actions',
+    event: 'push',
+    file: 'version-metadata/package.json',
+    expected: {
+      changed: true,
+      oldVersion: '1.0.11',
+      newVersion: '1.0.12'
+    }
+  },
+  {
     description:
       'fallback 0.0.0 version works with custom extractors (https://github.com/Quantco/slim-trees/actions/runs/5436331701/jobs/9886105283)',
     base: 'a30c62ac7f10f68aacc9ba5259246cae0056cc6d',


### PR DESCRIPTION
When creating a new branch the `before` value of the payload (`context.payload.before`) is set to `0000000000000000000000000000000000000000` and the `GITHUB_BASE_REF` environment variable isn't set (this seems like a bug); this deals with that by checking this exact `before` value and then doing an api call to determine the actual parent commit (of `context.payload.after`)